### PR TITLE
Fix/csv writting

### DIFF
--- a/Assets/Scripts/ExampleProgram.cs
+++ b/Assets/Scripts/ExampleProgram.cs
@@ -92,7 +92,6 @@ namespace Maes
                     100);
 
                 var scenarioBuilding = new SimulationScenario(
-                    hasFinishedSim: sim => sim.ExplorationTracker.ExploredProportion > 0.3f || sim.SimulatedLogicTicks > 360,
                     seed: randomSeed+i,
                     mapSpawner: generator => generator.GenerateMap(buildingConfig),
                     robotSpawner: (map, robotSpawner) => robotSpawner.SpawnRobotsTogether(

--- a/Assets/Scripts/SimulationManager.cs
+++ b/Assets/Scripts/SimulationManager.cs
@@ -164,7 +164,7 @@ namespace Maes {
         private bool UpdateSimulation() {
             if (_currentScenario != null && _currentScenario.HasFinishedSim(CurrentSimulation)) {
                 if (GlobalSettings.ShouldWriteCSVResults && _currentScenario.HasFinishedSim(CurrentSimulation))
-                    //CreateStatisticsFile();
+                    CreateStatisticsFile();
                 if (_scenarios.Count != 0) { //If last simulation, let us keep looking around in it
                     RemoveCurrentSimulation();
                 }

--- a/Assets/Scripts/SimulationScenario.cs
+++ b/Assets/Scripts/SimulationScenario.cs
@@ -66,8 +66,8 @@ namespace Maes
             RobotSpawner = robotSpawner ?? ((map, spawner) => spawner.SpawnRobotsTogether( map, seed, 2, 
                 Vector2Int.zero, (robotSeed) => new RandomExplorationAlgorithm(robotSeed)));
             RobotConstraints = robotConstraints ?? new RobotConstraints();
-            StatisticsFileName = statisticsFileName ?? $"statistics_{DateTime.Now.ToShortDateString().Replace('/','-')} " +
-                $"_{DateTime.Now.ToShortTimeString().Replace(' ','-')}";
+            StatisticsFileName = statisticsFileName ?? $"statistics_{DateTime.Now.ToShortDateString().Replace('/','-')}" +
+                $"_{DateTime.Now.ToLongTimeString().Replace(' ','-').Replace(':','-')}";
             
         }
         

--- a/Assets/Scripts/Statistics/ExplorationTracker.cs
+++ b/Assets/Scripts/Statistics/ExplorationTracker.cs
@@ -151,7 +151,7 @@ namespace Maes.Statistics {
             // In the first tick, the robot does not have a position in the slam map.
             if (!_isFirstTick) {
                 foreach (var robot in robots) UpdateCoverageStatus(robot);
-                calculateAverageDistance(robots);
+                mostRecentDistance = calculateAverageDistance(robots);
             } 
             else _isFirstTick = false;
 

--- a/Assets/Scripts/Statistics/StatisticsCSVWriter.cs
+++ b/Assets/Scripts/Statistics/StatisticsCSVWriter.cs
@@ -29,13 +29,13 @@ namespace Maes.Statistics
 {
     internal class StatisticsCSVWriter
     {
-        private readonly Simulation _simulation;
-        private readonly List<SnapShot<float>> _coverSnapShots;
-        private readonly List<SnapShot<float>> _exploreSnapShots;
-        private readonly List<SnapShot<float>> _distanceSnapShots;
-        private readonly Dictionary<int, SnapShot<bool>> _allAgentsConnectedSnapShots;
-        public readonly Dictionary<int, SnapShot<float>> _biggestClusterPercentageSnapShots;
-        private string path;
+        private Simulation _simulation { get; }
+        private List<SnapShot<float>> _coverSnapShots { get; }
+        private List<SnapShot<float>> _exploreSnapShots { get; }
+        private List<SnapShot<float>> _distanceSnapShots { get; }
+        private Dictionary<int, SnapShot<bool>> _allAgentsConnectedSnapShots { get; }
+        private Dictionary<int, SnapShot<float>> _biggestClusterPercentageSnapShots { get; }
+        private string _path { get; }
 
 
         public StatisticsCSVWriter(Simulation simulation, string fileNameWithoutExtension)
@@ -48,15 +48,15 @@ namespace Maes.Statistics
 
             _simulation = simulation;
             var resultForFileName =
-                $"e{(int)_exploreSnapShots[_exploreSnapShots.Count - 1].Value}-c{(int)_coverSnapShots[_coverSnapShots.Count - 1].Value}";
-            path = GlobalSettings.StatisticsOutPutPath + fileNameWithoutExtension + "_" + resultForFileName + ".csv";
+                $"e{(int)_exploreSnapShots[^1].Value}-c{(int)_coverSnapShots[^1].Value}";
+            _path = GlobalSettings.StatisticsOutPutPath + fileNameWithoutExtension + "_" + resultForFileName + ".csv";
         }
 
         public void CreateCSVFile(string separator)
         {
-            using var csv = new StreamWriter(path);
+            using var csv = new StreamWriter(_path);
             csv.WriteLine("Tick,Covered,Explored,Agents Interconnected, Biggest Cluster %");
-            for (int i = 0; i < _coverSnapShots.Count; i++)
+            for (var i = 0; i < _coverSnapShots.Count; i++)
             {
                 var tick = _coverSnapShots[i].Tick;
                 var coverage = "" + _coverSnapShots[i].Value;
@@ -65,21 +65,21 @@ namespace Maes.Statistics
                 StringBuilder line = new StringBuilder();
                 line.Append(
                     $"{"" + tick}{separator}{coverage}{separator}{explore}{separator}{distance}{separator}");
-                if (_allAgentsConnectedSnapShots.ContainsKey(tick))
+                if (_allAgentsConnectedSnapShots.TryGetValue(tick, out var agentsConnectedSnapShot))
                 {
-                    var allAgentsInterconnectedString = _allAgentsConnectedSnapShots[tick].Value ? "" + 1 : "" + 0;
+                    var allAgentsInterconnectedString = agentsConnectedSnapShot.Value ? "" + 1 : "" + 0;
                     line.Append($"{allAgentsInterconnectedString}");
                 }
 
                 line.Append($"{separator}");
-                if (_biggestClusterPercentageSnapShots.ContainsKey(tick))
+                if (_biggestClusterPercentageSnapShots.TryGetValue(tick, out var biggestClusterPercentageSnapShot))
                 {
-                    line.Append($"{_biggestClusterPercentageSnapShots[tick].Value}");
+                    line.Append($"{biggestClusterPercentageSnapShot.Value}");
                 }
 
                 csv.WriteLine(line.ToString());
             }
-            Debug.Log($"Writing statistics to path: {path}");
+            Debug.Log($"Writing statistics to path: {_path}");
         }
     }
 }

--- a/Assets/Scripts/Statistics/StatisticsCSVWriter.cs
+++ b/Assets/Scripts/Statistics/StatisticsCSVWriter.cs
@@ -25,8 +25,10 @@ using System.Text;
 using UnityEngine;
 using static Maes.Statistics.ExplorationTracker;
 
-namespace Maes.Statistics {
-    internal class StatisticsCSVWriter {
+namespace Maes.Statistics
+{
+    internal class StatisticsCSVWriter
+    {
         private readonly Simulation _simulation;
         private readonly List<SnapShot<float>> _coverSnapShots;
         private readonly List<SnapShot<float>> _exploreSnapShots;
@@ -34,45 +36,50 @@ namespace Maes.Statistics {
         private readonly Dictionary<int, SnapShot<bool>> _allAgentsConnectedSnapShots;
         public readonly Dictionary<int, SnapShot<float>> _biggestClusterPercentageSnapShots;
         private string path;
-        
 
-        public StatisticsCSVWriter(Simulation simulation, string fileNameWithoutExtension) {
+
+        public StatisticsCSVWriter(Simulation simulation, string fileNameWithoutExtension)
+        {
             _coverSnapShots = simulation.ExplorationTracker._coverSnapshots;
             _exploreSnapShots = simulation.ExplorationTracker._exploreSnapshots;
             _distanceSnapShots = simulation.ExplorationTracker._distanceSnapshots;
             _allAgentsConnectedSnapShots = simulation._communicationManager.CommunicationTracker.InterconnectionSnapShot;
             _biggestClusterPercentageSnapShots = simulation._communicationManager.CommunicationTracker.BiggestClusterPercentageSnapshots;
-            
+
             _simulation = simulation;
             var resultForFileName =
                 $"e{(int)_exploreSnapShots[_exploreSnapShots.Count - 1].Value}-c{(int)_coverSnapShots[_coverSnapShots.Count - 1].Value}";
-            path = GlobalSettings.StatisticsOutPutPath + fileNameWithoutExtension + "-" + resultForFileName + ".csv";
+            path = GlobalSettings.StatisticsOutPutPath + fileNameWithoutExtension + "_" + resultForFileName + ".csv";
         }
 
-        public void CreateCSVFile(string separator) {
-            var csv = new StringBuilder();
-            csv.AppendLine("Tick,Covered,Explored,Agents Interconnected, Biggest Cluster %");
-            for (int i = 0; i < _coverSnapShots.Count; i++) {
+        public void CreateCSVFile(string separator)
+        {
+            using var csv = new StreamWriter(path);
+            csv.WriteLine("Tick,Covered,Explored,Agents Interconnected, Biggest Cluster %");
+            for (int i = 0; i < _coverSnapShots.Count; i++)
+            {
                 var tick = _coverSnapShots[i].Tick;
                 var coverage = "" + _coverSnapShots[i].Value;
-                var explore = "" +_exploreSnapShots[i].Value;
-                var distance = ""+_distanceSnapShots[i].Value;
+                var explore = "" + _exploreSnapShots[i].Value;
+                var distance = "" + _distanceSnapShots[i].Value;
                 StringBuilder line = new StringBuilder();
-                line.Append($"{"" + tick}{separator}{coverage}{separator}{explore}{separator}{distance}{separator}");
-                if (_allAgentsConnectedSnapShots.ContainsKey(tick)) {
+                line.Append(
+                    $"{"" + tick}{separator}{coverage}{separator}{explore}{separator}{distance}{separator}");
+                if (_allAgentsConnectedSnapShots.ContainsKey(tick))
+                {
                     var allAgentsInterconnectedString = _allAgentsConnectedSnapShots[tick].Value ? "" + 1 : "" + 0;
                     line.Append($"{allAgentsInterconnectedString}");
                 }
+
                 line.Append($"{separator}");
-                if (_biggestClusterPercentageSnapShots.ContainsKey(tick)) {
+                if (_biggestClusterPercentageSnapShots.ContainsKey(tick))
+                {
                     line.Append($"{_biggestClusterPercentageSnapShots[tick].Value}");
                 }
-                
-                csv.AppendLine(line.ToString());
+
+                csv.WriteLine(line.ToString());
             }
-            
             Debug.Log($"Writing statistics to path: {path}");
-            File.WriteAllText(path, csv.ToString());
         }
     }
 }


### PR DESCRIPTION
- Change time format to not use ':' as it is NTFS alternate data streams, now on the format `statistics_dd-MM-yyyy_hh-mm-ss_eXX-cYY`, where e is exploration and c is coverage.
- Fix distance writing.
- Use StreamWriter to allow writing files exceeding RAM space for large simulations.